### PR TITLE
feat: Optimize docker-compose.yml for Podman

### DIFF
--- a/database/README.md
+++ b/database/README.md
@@ -1,0 +1,13 @@
+# Podman Optimization for docker-compose.yml
+
+This document outlines the changes made to the `docker-compose.yml` file to ensure compatibility with Podman.
+
+## Modifications
+
+The following modifications were made to the `database/docker-compose.yml` file:
+
+1.  **Removed `healthcheck`:** The `healthcheck` configuration was removed from the `db` service.
+
+## Reason for Changes
+
+The `healthcheck` directive in its `docker-compose.yml` format is not fully supported by `podman-compose`. To ensure seamless operation and avoid potential errors when running the application with Podman, this section was removed. The rest of the `docker-compose.yml` file is compatible with Podman and requires no further changes.

--- a/database/docker-compose.yml
+++ b/database/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.8'
 
 services:
   db:
-    image: postgres:16-alpine # Una imagen ligera de PostgreSQL 16
+    image: docker.io/library/postgres:16-alpine # Una imagen ligera de PostgreSQL 16
     container_name: clinica_db_postgres
     environment:
       POSTGRES_DB: clinica_db
@@ -14,9 +14,4 @@ services:
     volumes:
       - ./pg_data:/var/lib/postgresql/data # Persistencia de datos
       - ./init_db.sql:/docker-entrypoint-initdb.d/init_db.sql # Ejecuta el script SQL al inicio
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U user -d clinica_db"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
     restart: unless-stopped


### PR DESCRIPTION
This commit optimizes the `database/docker-compose.yml` file for use with Podman.

The following changes were made:
- The `healthcheck` directive was removed as it is not supported by `podman-compose`.
- The postgres image name was changed to the fully qualified name `docker.io/library/postgres:16-alpine` to avoid issues with unqualified image names in Podman.
- A `README.md` file was added to the `database` directory to document these changes.